### PR TITLE
Update `pre` tag to avoid whitespace at the front of the message

### DIFF
--- a/resources/js/Pages/Homepage/Index.vue
+++ b/resources/js/Pages/Homepage/Index.vue
@@ -133,9 +133,7 @@
 						frameborder="0"
 					/>
 					<pre v-else-if="view === 'html'" class="w-100 h-100"><code>{{ selectedEmail.body }}</code></pre>
-					<pre v-else class="text-sm w-100">
-                            {{ markdown }}
-                        </pre>
+					<pre v-else class="text-sm w-100">{{ markdown }}</pre>
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
Small change to stop the first line in the message content being indented due of the whitespace before it in the `<pre>` tags