### PR TITLE
Use pre-signed URLs for S3 attachment downloads

### DIFF
--- a/src/Http/Models/MailwebEmailAttachment.php
+++ b/src/Http/Models/MailwebEmailAttachment.php
@@ -35,6 +35,16 @@ class MailwebEmailAttachment extends Model
             return null;
         }
 
-        return Storage::disk(config('MailWeb.MAILWEB_ATTACHMENTS.DISK'))->url($this->path);
+        $disk = Storage::disk(config('MailWeb.MAILWEB_ATTACHMENTS.DISK'));
+
+        if (method_exists($disk, 'temporaryUrl')) {
+            try {
+                return $disk->temporaryUrl($this->path, now()->addMinutes(30));
+            } catch (\RuntimeException) {
+                // Driver doesn't support temporary URLs (e.g. local disk)
+            }
+        }
+
+        return $disk->url($this->path);
     }
 }


### PR DESCRIPTION
`Storage::url()` generates a plain public URL for attachments, which returns AccessDenied on private S3 buckets. This switches to `temporaryUrl()` to generate a pre-signed URL (valid for 30 minutes) instead, with a fallback to `url()` for disks that don't support it (e.g. local).